### PR TITLE
Add tenant-specific features

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,8 @@ import Routes from 'src/Routes'
 
 import './index.css'
 
+import { TenantProvider } from 'src/helpers/TenantContext'
+
 const extendedTheme = extendTheme(theme)
 
 const App = () => (
@@ -17,7 +19,9 @@ const App = () => (
       <ColorModeScript />
       <ChakraProvider theme={extendedTheme}>
         <RedwoodApolloProvider>
-          <Routes />
+          <TenantProvider>
+            <Routes />
+          </TenantProvider>
         </RedwoodApolloProvider>
       </ChakraProvider>
     </RedwoodProvider>

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -9,13 +9,26 @@
 
 import { Set, Router, Route } from '@redwoodjs/router'
 import HomeLayout from './layouts/HomeLayout'
+import TenantLayout from './layouts/TenantLayout'
 
 const Routes = () => {
+  type TenantLayoutProps = {
+    tenantData: {
+      name: string
+      logo: string
+      colorScheme: string
+      // ... add other tenant-specific properties
+    }
+  }
+
   return (
     <Router>
       <Set wrap={HomeLayout}>
         <Route path="/" page={HomePage} name="home" />
         <Route notfound page={NotFoundPage} />
+      </Set>
+      <Set wrap={TenantLayout}>
+        <Route path="/tenant/{tenantName}" page={TenantPage} name="tenant" />
       </Set>
     </Router>
   )

--- a/web/src/components/Tenant/FixieIframe/FixieIframe.stories.tsx
+++ b/web/src/components/Tenant/FixieIframe/FixieIframe.stories.tsx
@@ -1,0 +1,25 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import FixieIframe from './FixieIframe'
+
+const meta: Meta<typeof FixieIframe> = {
+  component: FixieIframe,
+}
+
+export default meta
+
+type Story = StoryObj<typeof FixieIframe>
+
+export const Primary: Story = {}

--- a/web/src/components/Tenant/FixieIframe/FixieIframe.test.tsx
+++ b/web/src/components/Tenant/FixieIframe/FixieIframe.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import FixieIframe from './FixieIframe'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('FixieIframe', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<FixieIframe />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Tenant/FixieIframe/FixieIframe.tsx
+++ b/web/src/components/Tenant/FixieIframe/FixieIframe.tsx
@@ -1,0 +1,19 @@
+import { Box, useColorModeValue } from '@chakra-ui/react'
+
+const FixieIframe = ({ src, title }) => {
+  return (
+    <Box
+      as="iframe"
+      src={src}
+      title={title}
+      width="80%"
+      height="500px"
+      frameBorder="1"
+      allowFullScreen
+      sandbox="allow-scripts allow-same-origin allow-popups"
+      backgroundColor={useColorModeValue('white', 'gray.800')}
+    />
+  )
+}
+
+export default FixieIframe

--- a/web/src/components/Tenant/Footer/Footer.stories.tsx
+++ b/web/src/components/Tenant/Footer/Footer.stories.tsx
@@ -1,0 +1,25 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import Footer from './Footer'
+
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+}
+
+export default meta
+
+type Story = StoryObj<typeof Footer>
+
+export const Primary: Story = {}

--- a/web/src/components/Tenant/Footer/Footer.test.tsx
+++ b/web/src/components/Tenant/Footer/Footer.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import Footer from './Footer'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('Footer', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<Footer />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Tenant/Footer/Footer.tsx
+++ b/web/src/components/Tenant/Footer/Footer.tsx
@@ -1,0 +1,46 @@
+import {
+  Box,
+  Container,
+  Flex,
+  Text,
+  Link,
+  Stack,
+  Center,
+  useColorModeValue,
+} from '@chakra-ui/react'
+
+const Footer = ({ companyName, primaryColor, secondaryColor }) => {
+  console.log('Footer primaryColor: ', primaryColor)
+  console.log('Footer secondaryColor: ', secondaryColor)
+
+  return (
+    <Box
+      as="footer"
+      role="contentinfo"
+      w="100%"
+      mx="auto"
+      py="6"
+      px={{ base: '4', md: '8' }}
+      backgroundColor={useColorModeValue(
+        `${primaryColor.light}`,
+        `${primaryColor.dark}`
+      )}
+      color={useColorModeValue(
+        `${secondaryColor.light}`,
+        `${secondaryColor.dark}`
+      )}
+    >
+      <Container maxW={'6xl'} py={2}>
+        <Center>
+          {/* <Flex direction={{ base: 'column', md: 'row' }} justify="space-between"> */}
+          <Text fontSize="lg">
+            © {new Date().getFullYear()} {companyName}. All rights reserved.
+          </Text>
+        </Center>
+        {/* </Flex> */}
+      </Container>
+    </Box>
+  )
+}
+
+export default Footer

--- a/web/src/components/Tenant/NavBar/NavBar.stories.tsx
+++ b/web/src/components/Tenant/NavBar/NavBar.stories.tsx
@@ -1,0 +1,25 @@
+// Pass props to your component by passing an `args` object to your story
+//
+// ```tsx
+// export const Primary: Story = {
+//  args: {
+//    propName: propValue
+//  }
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+import NavBar from './NavBar'
+
+const meta: Meta<typeof NavBar> = {
+  component: NavBar,
+}
+
+export default meta
+
+type Story = StoryObj<typeof NavBar>
+
+export const Primary: Story = {}

--- a/web/src/components/Tenant/NavBar/NavBar.test.tsx
+++ b/web/src/components/Tenant/NavBar/NavBar.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import NavBar from './NavBar'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('NavBar', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<NavBar />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Tenant/NavBar/NavBar.tsx
+++ b/web/src/components/Tenant/NavBar/NavBar.tsx
@@ -1,0 +1,39 @@
+import { Flex, Box, Image, Text, useColorModeValue } from '@chakra-ui/react'
+import { Button, useColorMode } from '@chakra-ui/react'
+
+const NavBar = ({ logo, companyName, primaryColor, secondaryColor }) => {
+  const { colorMode, toggleColorMode } = useColorMode()
+
+  return (
+    <Flex
+      as="nav"
+      align="center"
+      justify="space-between"
+      padding="1.5rem"
+      backgroundColor={useColorModeValue(
+        `${primaryColor.light}`,
+        `${primaryColor.dark}`
+      )}
+      color={useColorModeValue(
+        `${secondaryColor.light}`,
+        `${secondaryColor.dark}`
+      )}
+      boxShadow="sm"
+    >
+      <Flex align="center">
+        {logo && <Image src={logo} h="40px" mr="2rem" />}
+        <Text fontSize="lg" fontWeight="bold">
+          {companyName}
+        </Text>
+      </Flex>
+      <Flex>
+        <Button onClick={toggleColorMode}>
+          Toggle {colorMode === 'light' ? 'Dark' : 'Light'}
+        </Button>
+      </Flex>
+      {/* Additional Navbar content (e.g., navigation links) can be added here */}
+    </Flex>
+  )
+}
+
+export default NavBar

--- a/web/src/helpers/TenantContext.tsx
+++ b/web/src/helpers/TenantContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState } from 'react'
+
+const TenantContext = createContext({})
+
+export const TenantProvider = ({ children }) => {
+  const [tenantData, setTenantData] = useState({
+    name: '',
+    logo: '',
+    primaryColorScheme: {
+      light: '',
+      dark: '',
+    },
+    secondaryColorScheme: {
+      light: '',
+      dark: '',
+    },
+    textColorScheme: {
+      light: '',
+      dark: '',
+    },
+    fixieId: '',
+  })
+
+  // Provide a way to update the tenant data
+  const updateTenantData = (data) => {
+    setTenantData(data)
+  }
+
+  return (
+    <TenantContext.Provider value={{ tenantData, updateTenantData }}>
+      {children}
+    </TenantContext.Provider>
+  )
+}
+
+export const useTenant = () => useContext(TenantContext)

--- a/web/src/layouts/TenantLayout/TenantLayout.stories.tsx
+++ b/web/src/layouts/TenantLayout/TenantLayout.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import TenantLayout from './TenantLayout'
+
+const meta: Meta<typeof TenantLayout> = {
+  component: TenantLayout,
+}
+
+export default meta
+
+type Story = StoryObj<typeof TenantLayout>
+
+export const Primary: Story = {}

--- a/web/src/layouts/TenantLayout/TenantLayout.test.tsx
+++ b/web/src/layouts/TenantLayout/TenantLayout.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import TenantLayout from './TenantLayout'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('TenantLayout', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<TenantLayout />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/layouts/TenantLayout/TenantLayout.tsx
+++ b/web/src/layouts/TenantLayout/TenantLayout.tsx
@@ -1,0 +1,41 @@
+import { useTenant } from 'src/helpers/TenantContext'
+import { Box, Flex, Spacer, useColorModeValue } from '@chakra-ui/react'
+
+import NavBar from 'src/components/Tenant/NavBar'
+import Footer from 'src/components/Tenant/Footer'
+
+type TenantLayoutProps = {
+  children?: React.ReactNode
+}
+
+const TenantLayout = ({ children }: TenantLayoutProps) => {
+  const { tenantData } = useTenant()
+
+  return (
+    <Box minH="100vh">
+      <Flex direction="column" minH="100vh">
+        {/* NavBar */}
+        <NavBar
+          logo={tenantData.logo}
+          companyName={tenantData.name}
+          primaryColor={tenantData.primaryColorScheme}
+          secondaryColor={tenantData.textColorScheme}
+        />
+
+        {/* Main Content */}
+        <Flex flex="1" direction="column" as="main">
+          {children}
+        </Flex>
+
+        {/* Footer */}
+        <Footer
+          companyName={tenantData.name}
+          primaryColor={tenantData.primaryColorScheme}
+          secondaryColor={tenantData.textColorScheme}
+        />
+      </Flex>
+    </Box>
+  )
+}
+
+export default TenantLayout

--- a/web/src/pages/TenantPage/TenantPage.stories.tsx
+++ b/web/src/pages/TenantPage/TenantPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import TenantPage from './TenantPage'
+
+const meta: Meta<typeof TenantPage> = {
+  component: TenantPage,
+}
+
+export default meta
+
+type Story = StoryObj<typeof TenantPage>
+
+export const Primary: Story = {}

--- a/web/src/pages/TenantPage/TenantPage.test.tsx
+++ b/web/src/pages/TenantPage/TenantPage.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import TenantPage from './TenantPage'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('TenantPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<TenantPage />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/pages/TenantPage/TenantPage.tsx
+++ b/web/src/pages/TenantPage/TenantPage.tsx
@@ -1,0 +1,99 @@
+import { Link, routes } from '@redwoodjs/router'
+import { MetaTags } from '@redwoodjs/web'
+import { Flex, Heading, Text, useColorModeValue } from '@chakra-ui/react'
+
+import { useParams } from '@redwoodjs/router'
+import { useEffect, useState } from 'react'
+import { useTenant } from 'src/helpers/TenantContext'
+import FixieIframe from 'src/components/Tenant/FixieIframe/FixieIframe'
+
+// Mock tenant data
+const MOCK_TENANT_DATA = {
+  tenant1: {
+    name: 'Cleveland Whiskey',
+    primaryColorScheme: {
+      light: 'yellow.700',
+      dark: 'yellow.800',
+    },
+    secondaryColorScheme: {
+      light: 'yellow.400',
+      dark: 'yellow.500',
+    },
+    textColorScheme: {
+      light: 'whiteAlpha.900',
+      dark: 'whiteAlpha.900',
+    },
+    fixieId: '85a3ea3d-fa7b-458c-869e-43227309db63',
+    logo: 'https://via.placeholder.com/50',
+    // ... other tenant-specific attributes
+  },
+  tenant2: {
+    name: 'Cooper & Hawk Winery & Restaurants',
+    colorScheme: 'green',
+    primaryColorScheme: {
+      light: 'cyan.700',
+      dark: 'cyan.800',
+    },
+    secondaryColorScheme: {
+      light: 'cyan.400',
+      dark: 'cyan.500',
+    },
+    textColorScheme: {
+      light: 'whiteAlpha.900',
+      dark: 'whiteAlpha.900',
+    },
+    fixieId: '9780017c-4cd0-4bde-af04-f2ed14c2fc40',
+    logo: 'https://via.placeholder.com/50',
+    // ... other tenant-specific attributes
+  },
+  // ... add more tenants as needed
+}
+
+const TenantPage = () => {
+  const { tenantName } = useParams()
+  const { updateTenantData } = useTenant()
+  const { tenantData } = useTenant()
+
+  useEffect(() => {
+    // Simulate fetching data
+    const fetchTenantData = async () => {
+      // Simulate a delay
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      // Fetch data from the mock object
+      const data = MOCK_TENANT_DATA[tenantName]
+      updateTenantData(data)
+    }
+
+    fetchTenantData()
+  }, [tenantName, updateTenantData])
+
+  if (!tenantData) {
+    return <div>Loading or no tenant data found for {tenantName}</div>
+  }
+
+  return (
+    <>
+      <MetaTags title="Tenant" description="Tenant page" />
+
+      <Flex direction="column" align="center" justify="center" height="80vh">
+        <Heading as="h1" mb="4">
+          {tenantData.name}
+        </Heading>
+
+        <FixieIframe
+          src={`https://embed.fixie.ai/agents/${tenantData.fixieId}?agentStartsConversation=1`}
+          title={`${tenantData.name}'s Fixie AI Agent`}
+        />
+
+        {/* <iframe
+          src="https://embed.fixie.ai/agents/85a3ea3d-fa7b-458c-869e-43227309db63?debug=1&agentStartsConversation=1"
+          allow="clipboard-write"
+          style={{ width: '100%', height: '100vh' }}
+        /> */}
+      </Flex>
+    </>
+  )
+}
+
+export default TenantPage


### PR DESCRIPTION
Added several new features to start the build of the tenant structure. The goal is to allow us to dynamically set up customers and build their portal page based on attribute data. 

# Layouts
* TenantLayout - will hold the universal look and feel for all pages

# Pages
* TenantPage - will hold entry point into the customer page

# Components
* NavBar - will be our generic navigation
* Footer - will be our generic footer
* FixieIframe - will be used to display the fixie agent. this will become custom over time.

  ## Helper 
  * TenantContext - allows us to pass data up and down without depending on react lifecycle use event.


You can access it with the following examples.

* http://localhost:8910/tenant/tenant1 
* http://localhost:8910/tenant/tenant2
